### PR TITLE
Create run_main.yml

### DIFF
--- a/.github/workflows/run_main.yml
+++ b/.github/workflows/run_main.yml
@@ -1,0 +1,36 @@
+name: Run main.py
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  schedule: # Runs the workflow periodically
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: python:3.9
+        options: --user 1001
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run script
+      env:
+        MY_SECRET: ${{ secrets.MY_SECRET }}
+      run: |
+        python main.py


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the execution of the `main.py` script. The workflow is configured to run both manually and on a daily schedule.

Automation and scheduling:

* [`.github/workflows/run_main.yml`](diffhunk://#diff-93038b497abebd987596cfd261bec5517725e99e38819f89a522554179a4e2a1R1-R36): Added a new workflow file to run `main.py` on a daily schedule and allow manual triggering. The workflow sets up a Python environment, installs dependencies, and runs the script with a secret environment variable.main.pyを定期的またはトリガーに応じて実行するワークフロー